### PR TITLE
Add '|' as a status character when using pipe-pane

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -3117,6 +3117,7 @@ The flag is one of the following symbols appended to the window name:
 .It Li "!" Ta "A bell has occurred in the window."
 .It Li "+" Ta "Window is monitored for content and it has appeared."
 .It Li "~" Ta "The window has been silent for the monitor-silence interval."
+.It Li "|" Ta "The output of the active window pane is currently being piped to a program (pipe-pane)."
 .El
 .Pp
 The # symbol relates to the

--- a/window.c
+++ b/window.c
@@ -582,6 +582,8 @@ window_printable_flags(struct session *s, struct winlink *wl)
 		flags[pos++] = '+';
 	if (wl->flags & WINLINK_SILENCE)
 		flags[pos++] = '~';
+	if (wl->window->active->pipe_fd != -1)
+		flags[pos++] = '|';
 	if (wl == s->curw)
 		flags[pos++] = '*';
 	if (wl == TAILQ_FIRST(&s->lastw))


### PR DESCRIPTION
Update the window's flags when the output of the active window pane is currently being piped to a program (pipe-pane).  This is especially useful when using pipe-pane -o (toggle).
