### PR TITLE
configure: fixed to also search setupterm() in libtinfo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -135,7 +135,7 @@ fi
 # Look for curses.
 AC_SEARCH_LIBS(
 	setupterm,
-	[terminfo curses ncurses],
+	[terminfo curses ncurses tinfo],
 	found_curses=yes,
 	found_curses=no
 )


### PR DESCRIPTION
ncurses has build time configuration options to separate its different parts
into separate libraries.
If the configure switch '--with-termlib' is provided for example, the
terminfo part gets separtated into a single libtinfo, and thus it is including
setupterm().

This trivial change to configure.ac will change the behavior to also check for
setupterm() in libtinfo. This way the check for setupterm() is not failing on
systems with a separated libtinfo anymore.