### PR TITLE
Add option for restoring window zoom

### DIFF
--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -101,10 +101,13 @@ cmd_resize_pane_exec(struct cmd *self, struct cmd_q *cmdq)
 	w = wl->window;
 
 	if (args_has(args, 'Z')) {
-		if (w->flags & WINDOW_ZOOMED)
+		if (w->flags & WINDOW_ZOOMED) {
 			window_unzoom(w);
-		else
+			wp->flags &= ~PANE_ZOOMED;
+		} else {
 			window_zoom(wp);
+			wp->flags |= PANE_ZOOMED;
+		}
 		server_redraw_window(w);
 		server_status_window(w);
 		return (CMD_RETURN_NORMAL);

--- a/options-table.c
+++ b/options-table.c
@@ -604,6 +604,11 @@ const struct options_table_entry window_options_table[] = {
 	  .default_num = 0
 	},
 
+	{ .name = "restore-zoom",
+	  .type = OPTIONS_TABLE_FLAG,
+	  .default_num = 0
+	},
+
 	{ .name = "synchronize-panes",
 	  .type = OPTIONS_TABLE_FLAG,
 	  .default_num = 0

--- a/tmux.1
+++ b/tmux.1
@@ -2861,6 +2861,12 @@ The window may be reactivated with the
 .Ic respawn-window
 command.
 .Pp
+.It Xo Ic restore-zoom
+.Op Ic on | off
+.Xc
+A window with this flag set will autozoom after selecting a previously zoomed
+pane.
+.Pp
 .It Xo Ic synchronize-panes
 .Op Ic on | off
 .Xc

--- a/tmux.h
+++ b/tmux.h
@@ -904,6 +904,7 @@ struct window_pane {
 #define PANE_FOCUSED 0x4
 #define PANE_RESIZE 0x8
 #define PANE_FOCUSPUSH 0x10
+#define PANE_ZOOMED 0x20
 
 	char		*cmd;
 	char		*shell;


### PR DESCRIPTION
l find the zoom feature recently added very useful. When current pane is zoomed and you select another the current one is unzoomed to make the other visible, this is expected behaviour.

This patch implement the complementary behaviour: restore the zoom after selecting a pane that was previously zoomed.

The feature is controlled by window option `restore-zoom` which is set to _off_ by default.
