### PR TITLE
Remove unnecessary parameter setting for cygwin

### DIFF
--- a/server-client.c
+++ b/server-client.c
@@ -1203,7 +1203,6 @@ server_client_dispatch_identify(struct client *c, struct imsg *imsg)
 
 #ifdef __CYGWIN__
 	c->fd = open(c->ttyname, O_RDWR|O_NOCTTY);
-	c->cwd = open(".", O_RDONLY);
 #endif
 
 	if (c->flags & CLIENT_CONTROL) {


### PR DESCRIPTION
Recent modification, c->cwd paramter attribute is changed but there doesn't follow for cygwin environment. So tmux couldn't run on cygwin caused by "lost server".